### PR TITLE
GRFN-632: up ingest retries from 3 to 5 to compensate for tasks being…

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -44,8 +44,7 @@ Resources:
                   "MaxAttempts": 0
                 },
                 {
-                  "ErrorEquals": ["States.ALL"],
-                  "MaxAttempts": 5
+                  "ErrorEquals": ["States.ALL"]
                 }
               ],
               "Catch": [{
@@ -61,7 +60,8 @@ Resources:
               "ResultPath": "$.IngestResults",
               "Next": "Parallel",
               "Retry": [{
-                "ErrorEquals": ["States.ALL"]
+                "ErrorEquals": ["States.ALL"],
+                "MaxAttempts": 5
               }],
               "Catch": [{
                 "ErrorEquals": ["States.ALL"],


### PR DESCRIPTION
… discarded when scaling down the ECS fleet