### PR TITLE
GRFN-690: remove us-east-1f subnet from ingest fleet to avoid network…

### DIFF
--- a/ingest/cloudformation.yaml
+++ b/ingest/cloudformation.yaml
@@ -23,7 +23,7 @@ Parameters:
   SubnetId:
     Type: List<AWS::EC2::Subnet::Id>
     Description: Select at least two subnets in your selected VPC.
-    Default: subnet-25d39d19,subnet-5387281b,subnet-6083e36c,subnet-75658d2f,subnet-844ab8a8
+    Default: subnet-25d39d19,subnet-5387281b,subnet-75658d2f,subnet-844ab8a8
 
   Ami:
     Type: AWS::EC2::Image::Id


### PR DESCRIPTION
… connecivity errors for i3.xlarge machines