### PR TITLE
support granting publish access to multiple sds aws accounts

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -42,7 +42,7 @@ Parameters:
     - sa-east-1
 
   SdsAccountNumber:
-    Type: Number
+    Type: CommaDelimitedList
 
   CachedCmrTokenKey:
     Type: String
@@ -244,7 +244,7 @@ Resources:
         Statement:
         - Effect: Allow
           Principal:
-            AWS: !Sub "arn:aws:iam::${SdsAccountNumber}:root"
+            AWS: !Ref SdsAccountNumber
           Action: sns:Publish
           Resource: !Ref JobTopic
       Topics:


### PR DESCRIPTION
The ARIA system publishes new GUNW products to us to ingest by sending messages to the JobTopic SNS topic. The SdsAccountNumber stack parameter specifies the AWS account number of the ARIA system and grants only that AWS account permission to publish to the topic.

This PR changes the SdsAccountNumber paramter from a string to a comma delimited list, allowing one or more AWS accounts to be granted access to publish new products. The intent is for both the ARIA system and one or more new HyP3 deployments to all be able to publish products into our production CMR inventory.

See the `Type` attribute at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html for a description of the `CommaDelimitedList` parameter type.

See "AWS Account Principals" at https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html for the syntax of the IAM `Princial` field.

grfn-ingest deployments are managed using AWS CodePipeline. Merging to `test` should trigger the `ingest-test` pipeline in the GRFN AWS account to start a deployment. Merging to `prod` should trigger the `ingest-prod` pipeline. Values for the `SdsAccountNumber` parameter are specified in those pipelines for each deployment. We should be able to deploy these changes as-is, then update the parameter value to add one or more additional accounts at a later time.