### PR TITLE
do not copy s3 object tags when ingesting files

### DIFF
--- a/ingest/src/main.py
+++ b/ingest/src/main.py
@@ -21,6 +21,7 @@ def copy_s3_object(copy_source, dest_bucket, dest_key, transfer_config):
     extra_args = {
         'ContentType': content_type,
         'MetadataDirective': 'REPLACE',
+        'TaggingDirective': 'REPLACE',
     }
     s3.Bucket(dest_bucket).copy(CopySource=copy_source, Key=dest_key, ExtraArgs=extra_args, Config=transfer_config)
 


### PR DESCRIPTION
By default, `s3.Bucket.copy()` attempts to copy any object tags from the source object to the target object. However, our ingest lambda has not been granted `s3:GetObjectTagging` or `s3:PutObjectTagging` permissions, so attempting to ingest source files that have tags fails with "An error occurred (AccessDenied) when calling the CopyObject operation: Access Denied". This was never an issue when ingesting products generated by ARIA, since those objects do not have tags, but it's an issue when ingesting products from HyP3, which do have tags.

This PR changes the ingest behavior so ingested files will not have any tags, regardless of whether tags exist for the source object.

Current ingest lambda permissions are at https://github.com/asfadmin/grfn-ingest/blob/test/ingest/cloudformation.yaml#L36

The `ExtraArgs` parameter corresponds to the arguments for `s3.Object.copy_from()`: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Object.copy_from