### PR TITLE
increase throughput to 100 products/minute

### DIFF
--- a/invoke/cloudformation.yaml
+++ b/invoke/cloudformation.yaml
@@ -74,7 +74,7 @@ Resources:
           CONFIG: !Sub |-
             {
               "queue_url": "${QueueUrl}",
-              "max_messages_to_process": 50,
+              "max_messages_to_process": 100,
               "max_messages_per_receive": 10,
               "wait_time_in_seconds": 0,
               "message": {


### PR DESCRIPTION
The `invoke` lambda function is scheduled to run once per minute. The `max_messages_to_process` parameter controls how many ingest step functions are started per run of the lambda as a way to throttle the total throughput of the pipeline in case a million products get published for ingest all at the same time. It's the exact same idea as the `start_execution` lambda in HyP3.

In 2019 we [lowered the throughput](https://github.com/asfadmin/grfn-ingest/pull/161) from 250 to 50, but I can't find any context for *why*. I suspect we had an event where we were publishing too many products to CMR too fast and may have caused them issues.

We're now publishing products from HyP3, and HyP3 can generate products very quickly, so I'm upping our ingest throughput to make sure we can keep up. We'll want to keep an eye on things to make sure we're keeping up with the rate at which HyP3 is producing products, and that we're not causing CMR any undue stress.