### PR TITLE
remove dead letter queues for lambda functions

### DIFF
--- a/cmr-token/cloudformation.yaml
+++ b/cmr-token/cloudformation.yaml
@@ -38,12 +38,6 @@ Outputs:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "${Name}-dlq"
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -72,9 +66,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action: s3:PutObject
             Resource: !Sub "arn:aws:s3:::${TokenBucket}/${TokenKey}"
 
@@ -83,8 +74,6 @@ Resources:
     Properties:
       FunctionName: !Ref Name
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
       Environment:
         Variables:
           CONFIG: !Sub |-

--- a/echo10-construction/cloudformation.yaml
+++ b/echo10-construction/cloudformation.yaml
@@ -30,12 +30,6 @@ Outputs:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "${Name}-dlq"
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -64,9 +58,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action: s3:GetObject
             Resource:
             - !Sub "arn:aws:s3:::${PrivateBucket}/*"
@@ -81,8 +72,6 @@ Resources:
     Properties:
       FunctionName: !Ref Name
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
       Environment:
         Variables:
           CONFIG: !Sub |-

--- a/echo10-to-cmr/cloudformation.yaml
+++ b/echo10-to-cmr/cloudformation.yaml
@@ -28,12 +28,6 @@ Outputs:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "${Name}-dlq"
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -62,9 +56,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action: s3:GetObject
             Resource: !Sub "arn:aws:s3:::${AuxBucket}/*"
           - Effect: Allow
@@ -82,8 +73,6 @@ Resources:
     Properties:
       FunctionName: !Ref Name
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
       Environment:
         Variables:
           CONFIG: !Sub |-

--- a/ingest/cloudformation.yaml
+++ b/ingest/cloudformation.yaml
@@ -63,7 +63,6 @@ Resources:
     Properties:
       FunctionName: !Ref Name
       Code: src/
-
       Environment:
         Variables:
           CONFIG: !Sub |-

--- a/ingest/cloudformation.yaml
+++ b/ingest/cloudformation.yaml
@@ -21,12 +21,6 @@ Outputs:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "${Name}-dlq"
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -55,9 +49,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action: s3:GetObject
             Resource: arn:aws:s3:::*/*
           - Effect: Allow
@@ -72,8 +63,7 @@ Resources:
     Properties:
       FunctionName: !Ref Name
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
+
       Environment:
         Variables:
           CONFIG: !Sub |-

--- a/invoke/cloudformation.yaml
+++ b/invoke/cloudformation.yaml
@@ -16,12 +16,6 @@ Parameters:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "${Name}-dlq"
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -50,9 +44,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action:
             - sqs:GetQueueUrl
             - sqs:ReceiveMessage
@@ -67,8 +58,6 @@ Resources:
     Properties:
       FunctionName: !Ref Name
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
       Environment:
         Variables:
           CONFIG: !Sub |-

--- a/notify/cloudformation.yaml
+++ b/notify/cloudformation.yaml
@@ -35,12 +35,6 @@ Outputs:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "${Name}-dlq"
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -69,9 +63,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action: sns:Publish
             Resource: arn:aws:sns:*
 
@@ -80,8 +71,6 @@ Resources:
     Properties:
       FunctionName: !Ref Name
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
       Environment:
         Variables:
           CONFIG: !Sub |-

--- a/verify/cloudformation.yaml
+++ b/verify/cloudformation.yaml
@@ -12,12 +12,6 @@ Outputs:
 
 Resources:
 
-  DeadLetterQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      QueueName: !Sub "${Name}-dlq"
-      MessageRetentionPeriod: 1209600
-
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -46,9 +40,6 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
-            Action: sqs:SendMessage
-            Resource: !GetAtt DeadLetterQueue.Arn
-          - Effect: Allow
             Action: s3:GetObject
             Resource: arn:aws:s3:::*
           - Effect: Allow
@@ -60,8 +51,6 @@ Resources:
     Properties:
       FunctionName: !Ref Name
       Code: src/
-      DeadLetterConfig:
-        TargetArn: !GetAtt DeadLetterQueue.Arn
       Handler: main.lambda_handler
       MemorySize: 128
       Role: !GetAtt Role.Arn


### PR DESCRIPTION
[Dead Letter Queues](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-dlq) for the lambda functions are a relic of when we were chaining lambdas with asynchronous events, rather than step functions.