### PR TITLE
use yaml instead of json for sqs policy

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -226,7 +226,7 @@ Resources:
           Action: sqs:SendMessage
           Condition:
             ArnEquals:
-              aws:SourceArn: !Ref JobTopic
+              "aws:SourceArn": !Ref JobTopic
       Queues:
       - !Ref JobQueue
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -216,23 +216,17 @@ Resources:
   JobQueuePolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:
-      PolicyDocument: !Sub |-
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": "*",
-              "Resource": "${JobQueue.Arn}",
-              "Action": "sqs:SendMessage",
-              "Condition": {
-                "ArnEquals": {
-                  "aws:SourceArn": "${JobTopic}"
-                }
-              }
-            }
-          ]
-        }
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: sns.amazonaws.com
+          Resource: !GetAtt JobQueue.Arn
+          Action: sqs:SendMessage
+          Condition:
+            ArnEquals:
+              aws:SourceArn: !Ref JobTopic
       Queues:
       - !Ref JobQueue
 


### PR DESCRIPTION
JSON was previously required, but now yaml is supported, see the examples at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-policy.html#aws-properties-sqs-policy--examples

Also limits the principal to sns.amazonaws.com per https://docs.aws.amazon.com/sns/latest/dg/subscribe-sqs-queue-to-sns-topic.html#SendMessageToSQS.sqs.permissions