### PR TITLE
use launchpad to authenticate against cmr for ingest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ jobs:
             reformat_api_url: https://services.asf.alaska.edu/geospatial/reformat
             cmr_base_url: https://cmr.earthdata.nasa.gov
             cmr_provider: ASF
-            cmr_client_id: asf-grfn-prod
             deploy_ref: refs/heads/prod
 
           - environment: ingest-test
@@ -31,7 +30,6 @@ jobs:
             reformat_api_url: https://services-test.asf.alaska.edu/geospatial/reformat
             cmr_base_url: https://cmr.uat.earthdata.nasa.gov
             cmr_provider: ASF
-            cmr_client_id: asf-grfn-test
             deploy_ref: refs/heads/test
 
     environment:
@@ -86,7 +84,6 @@ jobs:
                 DefaultResponseTopicRegion='${{ secrets.DEFAULT_RESPONSE_TOPIC_REGION }}' \
                 SdsAccountNumber='${{ secrets.SDS_ACCOUNT_NUMBER }}' \
                 CmrBaseUrl='${{ matrix.cmr_base_url }}' \
-                CmrUsername='${{ secrets.CMR_USERNAME }}' \
-                CmrPassword='${{ secrets.CMR_PASSWORD }}' \
-                CmrProvider='${{ matrix.cmr_provider }}' \
-                CmrClientId='${{ matrix.cmr_client_id }}'
+                LaunchpadCertificateSecretArn='${{ secrets.LAUNCHPAD_CERTIFICATE_SECRET_ARN }}' \
+                LaunchpadPassphraseSecretArn='${{ secrets.LAUNCHPAD_PASSPHRASE_SECRET_ARN }}' \
+                CmrProvider='${{ matrix.cmr_provider }}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,5 +85,4 @@ jobs:
                 SdsAccountNumber='${{ secrets.SDS_ACCOUNT_NUMBER }}' \
                 CmrBaseUrl='${{ matrix.cmr_base_url }}' \
                 LaunchpadCertificateSecretArn='${{ secrets.LAUNCHPAD_CERTIFICATE_SECRET_ARN }}' \
-                LaunchpadPassphraseSecretArn='${{ secrets.LAUNCHPAD_PASSPHRASE_SECRET_ARN }}' \
                 CmrProvider='${{ matrix.cmr_provider }}'

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -58,9 +58,6 @@ Parameters:
   LaunchpadCertificateSecretArn:
     Type: String
 
-  LaunchpadPassphraseSecretArn:
-    Type: String
-
   CmrProvider:
     Type: String
 
@@ -123,7 +120,6 @@ Resources:
         TokenBucket: !Ref AuxBucket
         TokenKey: !Ref CachedCmrTokenKey
         CertificateSecretArn: !Ref LaunchpadCertificateSecretArn
-        PassphraseSecretArn: !Ref LaunchpadPassphraseSecretArn
       TemplateURL: cmr-token/cloudformation.yaml
 
   Echo10ToCmrStack:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -55,17 +55,13 @@ Parameters:
     - https://cmr.earthdata.nasa.gov
     - https://cmr.uat.earthdata.nasa.gov
 
-  CmrUsername:
+  LaunchpadCertificateSecretArn:
     Type: String
 
-  CmrPassword:
+  LaunchpadPassphraseSecretArn:
     Type: String
-    NoEcho: true
 
   CmrProvider:
-    Type: String
-
-  CmrClientId:
     Type: String
 
 Outputs:
@@ -126,11 +122,8 @@ Resources:
         Name: !Sub "${AWS::StackName}-cmr-token"
         TokenBucket: !Ref AuxBucket
         TokenKey: !Ref CachedCmrTokenKey
-        TokenUrl: !Sub "${CmrBaseUrl}/legacy-services/rest/tokens"
-        Username: !Ref CmrUsername
-        Password: !Ref CmrPassword
-        Provider: !Ref CmrProvider
-        ClientId: !Ref CmrClientId
+        CertificateSecretArn: !Ref LaunchpadCertificateSecretArn
+        PassphraseSecretArn: !Ref LaunchpadPassphraseSecretArn
       TemplateURL: cmr-token/cloudformation.yaml
 
   Echo10ToCmrStack:

--- a/cmr-token/cloudformation.yaml
+++ b/cmr-token/cloudformation.yaml
@@ -14,9 +14,6 @@ Parameters:
   CertificateSecretArn:
     Type: String
 
-  PassphraseSecretArn:
-    Type: String
-
 Outputs:
 
   LambdaName:
@@ -53,9 +50,7 @@ Resources:
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
             Action: secretsmanager:GetSecretValue
-            Resource:
-            - !Ref CertificateSecretArn
-            - !Ref PassphraseSecretArn
+            Resource: !Ref CertificateSecretArn
           - Effect: Allow
             Action: s3:PutObject
             Resource: !Sub "arn:aws:s3:::${TokenBucket}/${TokenKey}"
@@ -68,7 +63,6 @@ Resources:
       Environment:
         Variables:
           CERTIFICATE_SECRET_ARN: !Ref CertificateSecretArn
-          PASSPHRASE_SECRET_ARN: !Ref PassphraseSecretArn
           BUCKET: !Ref TokenBucket
           KEY: !Ref TokenKey
       Handler: main.lambda_handler

--- a/cmr-token/cloudformation.yaml
+++ b/cmr-token/cloudformation.yaml
@@ -11,24 +11,10 @@ Parameters:
   TokenKey:
     Type: String
 
-  TokenUrl:
-    Type: String
-    Default: https://cmr.earthdata.nasa.gov/legacy-services/rest/tokens
-    AllowedValues:
-    - https://cmr.earthdata.nasa.gov/legacy-services/rest/tokens
-    - https://cmr.uat.earthdata.nasa.gov/legacy-services/rest/tokens
-
-  Username:
+  CertificateSecretArn:
     Type: String
 
-  Password:
-    Type: String
-    NoEcho: true
-
-  Provider:
-    Type: String
-
-  ClientId:
+  PassphraseSecretArn:
     Type: String
 
 Outputs:
@@ -66,6 +52,11 @@ Resources:
             - logs:PutLogEvents
             Resource: !GetAtt LogGroup.Arn
           - Effect: Allow
+            Action: secretsmanager:GetSecretValue
+            Resource:
+            - !Ref CertificateSecretArn
+            - !Ref PassphraseSecretArn
+          - Effect: Allow
             Action: s3:PutObject
             Resource: !Sub "arn:aws:s3:::${TokenBucket}/${TokenKey}"
 
@@ -76,21 +67,10 @@ Resources:
       Code: src/
       Environment:
         Variables:
-          CONFIG: !Sub |-
-            {
-              "new_token": {
-                "username": "${Username}",
-                "password": "${Password}",
-                "url": "${TokenUrl}",
-                "provider": "${Provider}",
-                "client_id": "${ClientId}",
-                "user_ip_address": "0.0.0.0"
-              },
-              "cached_token": {
-                "bucket": "${TokenBucket}",
-                "key": "${TokenKey}"
-              }
-            }
+          CERTIFICATE_SECRET_ARN: !Ref CertificateSecretArn
+          PASSPHRASE_SECRET_ARN: !Ref PassphraseSecretArn
+          BUCKET: !Ref TokenBucket
+          KEY: !Ref TokenKey
       Handler: main.lambda_handler
       MemorySize: 128
       Role: !GetAtt Role.Arn

--- a/cmr-token/requirements.txt
+++ b/cmr-token/requirements.txt
@@ -1,6 +1,1 @@
-requests==2.23.0
-
-certifi==2019.11.28
-chardet==3.0.4
-idna==2.9
-urllib3==1.25.8
+requests-pkcs12==1.14

--- a/cmr-token/src/main.py
+++ b/cmr-token/src/main.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import os
 from logging import getLogger
 
@@ -10,14 +12,12 @@ s3 = boto3.client('s3')
 secrets_manager = boto3.client('secretsmanager')
 
 
-def get_secret_value(secret_arn: str):
+def get_secret_value(secret_arn: str) -> dict:
     response = secrets_manager.get_secret_value(SecretId=secret_arn)
-    if 'SecretBinary' in response:
-        return response['SecretBinary']
-    return response['SecretString']
+    return json.loads(response['SecretString'])
 
 
-def get_new_token(certificate: bytes, passphrase: str):
+def get_new_token(certificate: bytes, passphrase: str) -> str:
     response = requests_pkcs12.get(
         'https://api.launchpad.nasa.gov/icam/api/sm/v1/gettoken',
         pkcs12_data=certificate,
@@ -29,7 +29,9 @@ def get_new_token(certificate: bytes, passphrase: str):
 
 
 def lambda_handler(event, context):
-    certificate = get_secret_value(os.environ['CERTIFICATE_SECRET_ARN'])
-    passphrase = get_secret_value(os.environ['PASSPHRASE_SECRET_ARN'])
+    secret = get_secret_value(os.environ['CERTIFICATE_SECRET_ARN'])
+    certificate = base64.b64decode(secret['certificate'])
+    passphrase = secret['passphrase']
+
     token = get_new_token(certificate, passphrase)
     s3.put_object(Bucket=os.environ['BUCKET'], Key=os.environ['KEY'], Body=token)

--- a/cmr-token/src/main.py
+++ b/cmr-token/src/main.py
@@ -17,7 +17,7 @@ def get_secret_value(secret_arn: str):
     return response['SecretString']
 
 
-def get_new_token(certificate, passphrase):
+def get_new_token(certificate: bytes, passphrase: str):
     response = requests_pkcs12.get(
         'https://api.launchpad.nasa.gov/icam/api/sm/v1/gettoken',
         pkcs12_data=certificate,


### PR DESCRIPTION
HTTP requests to publish data to CMR require authentication via an `Echo-Token` header. We previously retrieved tokens using an Earthdata Login username and password, but that workflow will be retired in Q1 2023. With this PR we now retrieve tokens using a Launchpad certificate and passphrase.

See the [Launchpad Authentication User's Guide](https://wiki.earthdata.nasa.gov/display/CMR/Launchpad+Authentication+User%27s+Guide) for details on the transition from EDL to Launchpad.

See the [CMR Data Partner User Guide](https://wiki.earthdata.nasa.gov/display/CMR/CMR+Data+Partner+User+Guide) for all the details about how data is ingested into CMR.

This PR is heavily inspired by I&A already implementing Launchpad authentication, in particular:
- [fetch_launchpad_token](https://github.com/asfadmin/rain/blob/devel/code/md_insert/CmrRest.py#L91)
- [save_binary_secret_as_file](https://github.com/asfadmin/rain/blob/devel/code/md_insert/aws_secret.py#L88)

TODO
- [x] create Secrets Manager secret for certificate and passphrase
- [x] add `LAUNCHPAD_CERTIFICATE_SECRET_ARN` secret to ingest-test github environment
- [x] delete `CMR_USERNAME` and `CMR_PASSWORD` secrets from ingest-test github environment
- [x] add `LAUNCHPAD_CERTIFICATE_SECRET_ARN` secret to ingest-prod github environment
- [x] delete `CMR_USERNAME` and `CMR_PASSWORD` secrets from ingest-prod github environment