### PR TITLE
update verify metadata schema for v3 products only

### DIFF
--- a/tests/data/sds_metadata.json
+++ b/tests/data/sds_metadata.json
@@ -94,24 +94,6 @@
   "creation_timestamp": "2024-03-02T15:10:21.482183Z",
   "version": "3.0.0",
   "metadata": {
-    "ogr_bbox": [
-      [
-        37.61699395524997,
-        35.92252341193061
-      ],
-      [
-        40.798970046585445,
-        35.92252341193061
-      ],
-      [
-        40.798970046585445,
-        37.672665438632244
-      ],
-      [
-        37.61699395524997,
-        37.672665438632244
-      ]
-    ],
     "reference_scenes": [
       "S1A_IW_SLC__1SDV_20240212T032621_20240212T032649_052520_065A36_7976",
       "S1A_IW_SLC__1SDV_20240212T032646_20240212T032714_052520_065A36_4F51"
@@ -134,10 +116,7 @@
     ],
     "beam_mode": "IW",
     "orbit_direction": "descending",
-    "dataset_type": "slc",
-    "product_type": "interferogram",
     "polarization": "VV",
-    "look_direction": "right",
     "track_number": 123,
     "perpendicular_baseline": 56.0596,
     "frame_number": 19116

--- a/verify/src/metadata_schema.json
+++ b/verify/src/metadata_schema.json
@@ -45,7 +45,6 @@
     "metadata": {
       "type": "object",
       "required": [
-        "ogr_bbox",
         "reference_scenes",
         "secondary_scenes",
         "sensing_start",
@@ -54,22 +53,13 @@
         "platform",
         "beam_mode",
         "orbit_direction",
-        "dataset_type",
-        "product_type",
         "polarization",
-        "look_direction",
         "track_number",
-        "perpendicular_baseline"
+        "perpendicular_baseline",
+        "temporal_baseline_days",
+        "frame_number"
       ],
       "properties": {
-        "ogr_bbox": {
-          "type": "array",
-          "minItems": 4,
-          "maxItems": 4,
-          "items": {
-            "#ref": "#/definitions/coordinate"
-          }
-        },
         "reference_scenes": {
           "$ref": "#/definitions/granule_list"
         },
@@ -106,19 +96,9 @@
           "type": "string",
           "enum": ["ascending", "descending"]
         },
-        "dataset_type": {
-          "type": "string"
-        },
-        "product_type": {
-          "type": "string"
-        },
         "polarization": {
           "type": "string",
           "enum": ["VV", "HH", "VV+VH", "HH+HV"]
-        },
-        "look_direction": {
-          "type": "string",
-          "enum": ["right", "left"]
         },
         "track_number": {
           "type": "integer",


### PR DESCRIPTION
Our `verify` module checks that the metadata file sent to us by the SDS has all the metadata fields we need. Previously we supported both v2 an v3 metadata. Now that we're only going to support v3 products, we can relax the requirements for the metadata file:

We don't use the `ogr_bbox`, `dataset_type`, `product_type`, or `look_direction` fields any more, so we no longer need to check for them.

We can make the `temporal_baseline_days` and `frame_number` fields required. These were added in v3, but we couldn't require them while we were still also supporting v2. `weather_model` is still optional; it's not included in the sds metadata at all for products that didn't use a weather model.