### PR TITLE
add maximum frame_number when verifying sds metadata file

### DIFF
--- a/verify/src/metadata_schema.json
+++ b/verify/src/metadata_schema.json
@@ -128,7 +128,8 @@
         },
         "frame_number": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 27397
         }
       }
     }


### PR DESCRIPTION
Per the DockerizedTopsApp [readme](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp?tab=readme-ov-file#what-makes-an-aria-s1-gunw-product-standard), the list of GUNW frames is [here](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/blob/dev/isce2_topsapp/data/s1_frames_latitude_aligned.geojson.zip). I confirmed the frame IDs in that geojson file range from 0 to 27397.