### PR TITLE
update metadata-construction to handle s3 keys that include folder prefixes

### DIFF
--- a/metadata-construction/src/metadata_construction.py
+++ b/metadata-construction/src/metadata_construction.py
@@ -55,7 +55,7 @@ def format_polygon(polygon):
     return coordinates
 
 
-def render_granule_metadata(sds_metadata, config, product) -> dict:
+def render_granule_metadata(sds_metadata, config, product, browse) -> dict:
     granule_ur = sds_metadata['label']
     download_url = config['granule_data']['download_path']
     browse_url = config['granule_data']['browse_path']
@@ -74,11 +74,11 @@ def render_granule_metadata(sds_metadata, config, product) -> dict:
         },
         'RelatedUrls': [
             {
-                'URL': f'{download_url}/{granule_ur}.nc',
+                'URL': f'{download_url}/{product["Key"]}',
                 'Type': 'GET DATA',
             },
             {
-                'URL': f'{browse_url}/{granule_ur}.png',
+                'URL': f'{browse_url}/{browse["Key"]}',
                 'Type': 'GET RELATED VISUALIZATION',
             },
         ],
@@ -114,7 +114,7 @@ def render_granule_metadata(sds_metadata, config, product) -> dict:
         "DataGranule": {
             "ArchiveAndDistributionInformation": [
                 {
-                    "Name": product['Key'],
+                    "Name": os.path.basename(product['Key']),
                     "SizeInBytes": get_s3_file_size(product)
                 }
             ],
@@ -144,7 +144,7 @@ def render_granule_metadata(sds_metadata, config, product) -> dict:
 def create_granule_metadata_in_s3(inputs, config):
     log.info('Creating metadata file for %s', inputs['Product']['Key'])
     sds_metadata = get_sds_metadata(inputs['Metadata'])
-    umm_json = render_granule_metadata(sds_metadata, config, inputs['Product'])
+    umm_json = render_granule_metadata(sds_metadata, config, inputs['Product'], inputs['Browse'])
     output_location = {
         'bucket': config['output_bucket'],
         'key': umm_json['GranuleUR'] + '.umm.json',

--- a/tests/data/granule2/granule.umm.json
+++ b/tests/data/granule2/granule.umm.json
@@ -56,7 +56,7 @@
   "DataGranule": {
     "ArchiveAndDistributionInformation": [
       {
-        "Name": "product/S1-GUNW-A-R-018-tops-20230329_20230221-232745-00072W_00038S-PP-1cfc-v3_0_1.nc",
+        "Name": "S1-GUNW-A-R-018-tops-20230329_20230221-232745-00072W_00038S-PP-1cfc-v3_0_1.nc",
         "SizeInBytes": 789
       }
     ],
@@ -104,11 +104,11 @@
   "RelatedUrls": [
     {
       "Type": "GET DATA",
-      "URL": "https://download-path.asf.alaska.edu/S1-GUNW-A-R-018-tops-20230329_20230221-232745-00072W_00038S-PP-1cfc-v3_0_1.nc"
+      "URL": "https://download-path.asf.alaska.edu/product/S1-GUNW-A-R-018-tops-20230329_20230221-232745-00072W_00038S-PP-1cfc-v3_0_1.nc"
     },
     {
       "Type": "GET RELATED VISUALIZATION",
-      "URL": "https://browse-path.asf.alaska.edu/S1-GUNW-A-R-018-tops-20230329_20230221-232745-00072W_00038S-PP-1cfc-v3_0_1.png"
+      "URL": "https://browse-path.asf.alaska.edu/browse/S1-GUNW-A-R-018-tops-20230329_20230221-232745-00072W_00038S-PP-1cfc-v3_0_1.png"
     }
   ],
   "SpatialExtent": {


### PR DESCRIPTION
This doesn't currently matter since we don't use folder prefixes when storing files in S3. But if we were to better organize our files by using prefixes, such as in https://github.com/asfadmin/grfn-ingest/blob/dev/tests/data/granule2/inputs.json , I'd want the filename to not include the prefix, and the download URLs to include the prefixes.