### PR TITLE
remove pin of requests in requirements-cmr-token.txt

### DIFF
--- a/requirements-cmr-token.txt
+++ b/requirements-cmr-token.txt
@@ -1,3 +1,2 @@
 boto3==1.34.131
-requests==2.32.3
 requests-pkcs12==1.25


### PR DESCRIPTION
Requests v2.23.0 broke requests-pkcs12 v1.24, see https://github.com/m-click/requests_pkcs12/issues/55 . We'd pinned to requests v2.31.0 as an immediate workaround:

- https://github.com/asfadmin/grfn-ingest/pull/497
- https://github.com/asfadmin/grfn-ingest/issues/496

The issue's been addressed in requests-pkcs12 v1.25, so there's no longer a need to include a specific version of requests in the requirements file.